### PR TITLE
Bugfix/cneservice

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -174,7 +174,6 @@ lib/libOmxVpp.so:vendor/lib/libOmxVpp.so
 lib/libvpplibrary.so:vendor/lib/libvpplibrary.so|03d8f12bfa8cfbfa193492e65122e981bc8ab52e
 lib64/libdashplayer.so:vendor/lib64/libdashplayer.so
 lib64/libdhcpcd.so:vendor/lib64/libdhcpcd.so
--priv-app/CNEService/CNEService.apk
 -priv-app/qcrilmsgtunnel/qcrilmsgtunnel.apk
 vendor/bin/mm-pp-daemon
 vendor/bin/qti

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -46,8 +46,8 @@ vendor/lib64/libxtwifi_ulp_adaptor.so|078124cc018badf89c1f5588e9102e9f7c034da2
 vendor/lib64/vendor.qti.gnss@1.0_vendor.so|249c76153f8de014bf2dd2ab623ee3d87741fbc8
 
 # Perf
-lib/vendor.qti.hardware.perf@1.0.so|cd7ddfd240d8a980396c10ffc01070713518087d
-lib64/vendor.qti.hardware.perf@1.0.so|db6d62913453c545bd057866aeb37a0d058bf6f6
+vendor/lib/vendor.qti.hardware.perf@1.0.so|cd7ddfd240d8a980396c10ffc01070713518087d
+vendor/lib64/vendor.qti.hardware.perf@1.0.so|db6d62913453c545bd057866aeb37a0d058bf6f6
 
 vendor/bin/hw/vendor.qti.hardware.perf@1.0-service|e34d3ab597388add3c68d0583cbb4e3a3fc5921e
 vendor/etc/init/vendor.qti.hardware.perf@1.0-service.rc|b50182aadab2e31409df61c523d0fb914a394e43


### PR DESCRIPTION
The important commit is "proprietary-files.txt: remove CNEService app". See commit message for an explanation.
This was already applied to proprietary_vendor_lenovo via https://github.com/Lenovo-YTX703-Devel/proprietary_vendor_lenovo/commit/0f71b8332d0260570421add01fa44a7eb15469cf and https://github.com/Lenovo-YTX703-Devel/proprietary_vendor_lenovo/commit/a43f7cfa691499929a4638f806f192274981df68.
This pull request is to bring the device repository up to date with the proprietary_vendor_lenovo changes.