### PR TITLE
sepolicy: confine com.sony.timekeep to timekeep_app domain

### DIFF
--- a/sepolicy/installd.te
+++ b/sepolicy/installd.te
@@ -1,0 +1,2 @@
+allow installd time_data_file:dir { create_dir_perms relabelfrom relabelto };
+

--- a/sepolicy/seapp_contexts
+++ b/sepolicy/seapp_contexts
@@ -1,4 +1,6 @@
 # Create dataservice_app domain for /system/priv-app/QtiTetherService package
 # Go match device/qcom/sepolicy/common/dataservice_app.te
 user=system domain=dataservice_app seinfo=platform name=com.qualcomm.qti.tetherservice type=system_app_data_file
+# Label the TimeKeep service as timekeep_app, and its files in /data/data/com.sony.timekeep as time_data_file
+user=system seinfo=platform name=com.sony.timekeep domain=timekeep_app type=time_data_file
 

--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,6 +1,0 @@
-# Rule is for the Java part of timekeep (com.sony.timekeep).
-
-allow system_app time_data_file:dir search;
-allow system_app time_data_file:file rw_file_perms;
-
-set_prop(system_app, timekeep_prop)

--- a/sepolicy/timekeep_app.te
+++ b/sepolicy/timekeep_app.te
@@ -1,0 +1,17 @@
+type timekeep_app, domain;
+app_domain(timekeep_app)
+
+# Rules for the Java part of timekeep (com.sony.timekeep).
+
+allow timekeep_app time_data_file:dir  rw_dir_perms;
+allow timekeep_app time_data_file:file rw_file_perms;
+allow timekeep_app sysfs:file          r_file_perms;
+# For /sys/class/rtc/rtc0/since_epoch
+
+allow timekeep_app activity_service:service_manager find;
+allow timekeep_app display_service:service_manager find;
+allow timekeep_app network_management_service:service_manager find;
+allow timekeep_app connectivity_service:service_manager find;
+
+set_prop(timekeep_app, timekeep_prop)
+


### PR DESCRIPTION
* Previously, the Java app was running in the system_app domain, and it
  was therefore necessary to add overly permissive rules to the more
  general domain. These are now given only to the TimeKeep app.