### PR TITLE
systemprops: Define Vendor security patch level to 2018-05-01

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -98,6 +98,9 @@ ro.vendor.gt_library=libqti-gt.so
 # used by libqti-gt.so
 sched.colocate.enable=1
 
+# Vendor security patch level
+ro.lineage.build.vendor_security_patch=2018-05-01
+
 # Time
 persist.timed.enable=true
 


### PR DESCRIPTION
* This is needed for Trust, as we don't have a Vendor image that sets a
valid vendor security patch level.
* Taken from the YT-X703L_S000973_180524_ROW Image.

Change-Id: Ie9a09084fc2bca59c8867f782fa498e2a0c9fb0d