### PR TITLE
cnss-daemon: Remove cnss-daemon

### DIFF
--- a/config.fs
+++ b/config.fs
@@ -47,12 +47,6 @@ user: AID_SYSTEM
 group: AID_SYSTEM
 caps: NET_BIND_SERVICE BLOCK_SUSPEND NET_ADMIN
 
-[vendor/bin/cnss-daemon]
-mode: 0755
-user: AID_SYSTEM
-group: AID_SYSTEM
-caps: NET_BIND_SERVICE
-
 [vendor/bin/ims_rtp_daemon]
 mode: 0755
 user: AID_SYSTEM

--- a/configs/init/cnss-daemon.rc
+++ b/configs/init/cnss-daemon.rc
@@ -1,7 +1,0 @@
-# vim: set ft=sh:
-
-service cnss-daemon /vendor/bin/cnss-daemon -n -l
-    class late_start
-    user system
-    group system inet net_admin wifi radio
-

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -148,7 +148,6 @@ vendor/lib/libsmwrapper.so
 bin/adsprpcd:vendor/bin/adsprpcd
 bin/btnvtool:vendor/bin/btnvtool
 bin/cnd:vendor/bin/cnd|d876882efffa12a235bc2dbba02ebddb7dd3ccb6
-bin/cnss-daemon:vendor/bin/cnss-daemon
 bin/dpmd:vendor/bin/dpmd
 
 bin/hci_qcomm_init:vendor/bin/hci_qcomm_init


### PR DESCRIPTION
* Not used on prima, for these wlan chipsets wcnss is used instead.

Change-Id: I2fe5b8e95e372b0c8ba40f0e5f928c60c0aa6645