### PR TITLE
[CM14] sepolicy: give timekeep_app full creation access to its own private files

### DIFF
--- a/sepolicy/timekeep_app.te
+++ b/sepolicy/timekeep_app.te
@@ -3,8 +3,8 @@ app_domain(timekeep_app)
 
 # Rules for the Java part of timekeep (com.sony.timekeep).
 
-allow timekeep_app time_data_file:dir  rw_dir_perms;
-allow timekeep_app time_data_file:file rw_file_perms;
+allow timekeep_app time_data_file:dir  create_dir_perms;
+allow timekeep_app time_data_file:file create_file_perms;
 allow timekeep_app sysfs:file          r_file_perms;
 # For /sys/class/rtc/rtc0/since_epoch
 


### PR DESCRIPTION
* This denial is only visible only after a fresh installation of LineageOS,
  hence the reason why I missed it the first time.

Change-Id: I1cad25c126cc3616435a5b48d9f66fca690e9f1a
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>