### PR TITLE
[CM14] BoardConfig: generate builds that are compatible with both the old and new TWRP

### DIFF
--- a/YTX703F/BoardConfig.mk
+++ b/YTX703F/BoardConfig.mk
@@ -17,6 +17,6 @@
 # inherit from the common version
 -include device/lenovo/YTX703-common/BoardConfigCommon.mk
 
-# Assert
-TARGET_OTA_ASSERT_DEVICE := yt_x703f
+# For build/make/tools/releasetools/edify_generator.py
+TARGET_OTA_ASSERT_DEVICE := YTX703F,yt_x703f
 

--- a/YTX703L/BoardConfig.mk
+++ b/YTX703L/BoardConfig.mk
@@ -17,8 +17,8 @@
 # inherit from the common version
 -include device/lenovo/YTX703-common/BoardConfigCommon.mk
 
-# Assert
-TARGET_OTA_ASSERT_DEVICE := yt_x703l
+# For build/make/tools/releasetools/edify_generator.py
+TARGET_OTA_ASSERT_DEVICE := YTX703L,yt_x703l
 
 # Radio
 TARGET_RIL_VARIANT := caf


### PR DESCRIPTION
This is actually cherry-picked from the feature/twrp-support pull request on lineage-15.1.
No point in supporting TWRP both in the cm14 and lineage-15.1 branches, but at least we can build the final cm14 images in a way that is going to be future-compatible with the lineage-15.1 TWRP image.

Change-Id: I034c202ed8b9cca13ce8c4a940e467861f2b67dc
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>