### PR TITLE
[CM14] device-common.mk: remove /rfs ramdisk symlinks since they are unused

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -267,27 +267,6 @@ PRODUCT_COPY_FILES += $(foreach service, $(wildcard $(LOCAL_PATH)/configs/init/*
     $(service):$(addprefix system/etc/init/, $(notdir $(service))) )
 
 #
-# Ramdisk symlinks.
-# Parsed by system/core/rootdir/Android.mk
-#
-
-# Create RFS MSM ADSP folder structure
-BOARD_ROOT_EXTRA_SYMLINKS += \
-    /data/tombstones/lpass:rfs/msm/adsp/ramdumps \
-    /persist/rfs/msm/adsp:rfs/msm/adsp/readwrite \
-    /persist/rfs/shared:rfs/msm/adsp/shared \
-    /persist/hlos_rfs/shared:rfs/msm/adsp/hlos \
-    /system/etc/firmware:rfs/msm/adsp/readonly/firmware \
-
-# Create RFS MSM MPSS folder structure
-BOARD_ROOT_EXTRA_SYMLINKS += \
-    /data/tombstones/modem:rfs/msm/mpss/ramdumps \
-    /persist/rfs/msm/mpss:rfs/msm/mpss/readwrite \
-    /persist/rfs/shared:rfs/msm/mpss/shared \
-    /persist/hlos_rfs/shared:rfs/msm/mpss/hlos \
-    /system/etc/firmware:rfs/msm/mpss/readonly/firmware \
-
-#
 # System partition symlinks.
 # Parsed by vendor/cm/build/tasks/target_symlinks.mk
 #


### PR DESCRIPTION
* These are probably relics from another SoC that were present in the
  stock code. The only file that matches for '/rfs/msm' is
  /system/bin/tftp_server, which we do not ship in LineageOS.
* It is most certain that there is currently no user for these symlinks,
  as the files themselves are unlabeled from SELinux perspective.
  Therefore, any attempt to access them would have resulted in a denial.
* https://github.com/Lenovo-YTX703-Devel/android_device_lenovo_YTX703-common/issues/10
* This is a backport to cm14 of https://github.com/Lenovo-YTX703-Devel/android_device_lenovo_YTX703-common/pull/12

Change-Id: Ia502136e55fdca93ea552ffd33568c2acedab7e8
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>