### PR TITLE
init: Remove cpuset foreground boost

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -22,7 +22,6 @@ on boot
     # Update foreground cpuset now that processors are up
     # reserve CPU 3 for the top app and camera daemon
     write /dev/cpuset/foreground/cpus 0-2,4-7
-    write /dev/cpuset/foreground/boost/cpus 4-7
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-2
     write /dev/cpuset/top-app/cpus 0-7


### PR DESCRIPTION
Cpuset foreground boost is departed since
https://android.googlesource.com/platform/frameworks/base/+/a712d4058f6f85268838

Taken from
https://review.lineageos.org/#/c/LineageOS/android_device_xiaomi_msm8998-common/+/219904/

Change-Id: Iab1834dbb8cce15480b5e11968bcfff7cc80177e
Signed-off-by: Lennart Wieboldt <lennart.1997@gmx.de>